### PR TITLE
Feature/artist show page

### DIFF
--- a/app/assets/javascripts/artists.coffee
+++ b/app/assets/javascripts/artists.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/artists.scss
+++ b/app/assets/stylesheets/artists.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the artists controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,6 +1,6 @@
 class Admin::EventsController < Admin::BaseController
   
-  before_action :set_event, only: [:edit, :update, :destroy]
+  before_action :set_event, only: [:edit, :update, :destroy, :remove_artist]
 
   ALLOW_QUERIES = %w[s artist_name_cont title_cont city_cont date_cont time_cont stage_eq stage_cont views_count interests_count detail_cont artist_name_or_title_or_city_or_detail_cont date_lteq date_gteq views_count_gteq interests_count_gteq updated_at].freeze
 
@@ -27,6 +27,15 @@ class Admin::EventsController < Admin::BaseController
 
   def destroy
     @event.destroy
+  end
+
+  def remove_artist
+    @event.artist_name = nil
+    @event.artist_id = nil
+    @event.video = nil
+    @event.spotify_artist_id = nil
+    @event.save!
+    redirect_back(fallback_location: root_path)
   end
 
   private 

--- a/app/controllers/admin/stream.rb
+++ b/app/controllers/admin/stream.rb
@@ -9,71 +9,17 @@ class Admin::Stream
         if event.title.include?(artist.name)
           event.artist_name = artist.name
           event.artist_id = artist.id
-          # YT
-          searching = artist.name
-
-          if Rails.env.development?
-            # local用
-            yt_config = Rails.application.config_for(:youtube)
-            url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{yt_config["app_id"]}&q=#{searching}&type=video&maxResults=1"
-          elsif Rails.env.production?
-            # heroku用
-            url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{ENV['YOUTUBE_APP_ID']}&q=#{searching}&type=video&maxResults=1"
-          end
-
-          response = RestClient.get(URI::encode(url))
-          data = JSON.parse(response.body)
-          if data["items"] != []
-            id = data["items"][0]["id"]["videoId"]
-            event.video = "https://www.youtube.com/embed/#{id}?enablejsapi=1"
-          end
-
-          # spotify
-          @spotify_data = event.get_spotify_data(artist.name)
-          if @spotify_data == nil
-            @spotify_artist_id = nil
-          else
-            event.spotify_artist_id = @spotify_data.id
-          end
-
+          event.video = artist.artist_video
+          event.spotify_artist_id = artist.artist_spotify_id
           event.save!
-
         elsif event.detail.include?(artist.name)
           event.artist_name = artist.name
           event.artist_id = artist.id
-          # YT
-          searching = artist.name
-
-          if Rails.env.development?
-            # local用
-            yt_config = Rails.application.config_for(:youtube)
-            url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{yt_config["app_id"]}&q=#{searching}&type=video&maxResults=1"
-          elsif Rails.env.production?
-            # heroku用
-            url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{ENV['YOUTUBE_APP_ID']}&q=#{searching}&type=video&maxResults=1"
-          end
-
-          response = RestClient.get(URI::encode(url))
-          data = JSON.parse(response.body)
-          if data["items"] != []
-            id = data["items"][0]["id"]["videoId"]
-            event.video = "https://www.youtube.com/embed/#{id}?enablejsapi=1"
-          end
-
-          # spotify
-          @spotify_data = event.get_spotify_data(artist.name)
-          if @spotify_data == nil
-            @spotify_artist_id = nil
-          else
-            event.spotify_artist_id = @spotify_data.id
-          end
-
-          event.save!
-              
+          event.video = artist.artist_video
+          event.spotify_artist_id = artist.artist_spotify_id
+          event.save! 
         end
-
       end
-
 
     end
 
@@ -84,12 +30,57 @@ class Admin::Stream
     @events.each do |event|
       event.artist_name = artist.name
       if event.video != nil && event.video != "" && event.spotify_artist_id != nil && event.spotify_artist_id != ""
+        event.video = artist.artist_video
+        event.spotify_artist_id = artist.artist_spotify_id
         event.save!
-      elsif  event.video == nil || event.video == ""
-        event.artist_name = artist.name
-        # YT
-        searching = artist.name
+      else
+        event.video = artist.artist_video
+        event.spotify_artist_id = artist.artist_spotify_id
+        event.save!
+        check_event_artist(artist)
+      end
+      
+    end
+  end
 
+  def self.create_stream_data(artist)
+
+    searching = artist.name
+    
+    if Rails.env.development?
+      # local用
+      yt_config = Rails.application.config_for(:youtube)
+      url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{yt_config["app_id"]}&q=#{searching}&type=video&maxResults=1"
+    elsif Rails.env.production?
+      # heroku用
+      url = "https://www.googleapis.com/youtube/v3/search?part=snippet&key=#{ENV['YOUTUBE_APP_ID']}&q=#{searching}&type=video&maxResults=1"
+    end
+
+    response = RestClient.get(URI::encode(url))
+    data = JSON.parse(response.body)
+    if data["items"] != []
+      id = data["items"][0]["id"]["videoId"]
+      artist.artist_video = "https://www.youtube.com/embed/#{id}?enablejsapi=1"
+    end
+
+    # spotify
+    spotify_data = artist.get_spotify_data(artist.name)
+    if spotify_data == nil
+      artist.artist_spotify_id = nil
+    else
+      artist.artist_spotify_id = spotify_data.id
+    end
+    artist.save!
+
+  end
+
+
+  def self.check_stream_data(temp_video, temp_spotify_id, artist)
+
+    if (temp_video == nil || temp_video == "") && (temp_spotify_id == nil || temp_spotify_id == "")
+      if artist.artist_video == nil || artist.artist_video == ""
+        searching = artist.name
+        
         if Rails.env.development?
           # local用
           yt_config = Rails.application.config_for(:youtube)
@@ -103,39 +94,31 @@ class Admin::Stream
         data = JSON.parse(response.body)
         if data["items"] != []
           id = data["items"][0]["id"]["videoId"]
-          event.video = "https://www.youtube.com/embed/#{id}?enablejsapi=1"
+          artist.artist_video = "https://www.youtube.com/embed/#{id}?enablejsapi=1"
         end
 
-        if event.spotify_artist_id == nil || event.spotify_artist_id == ""
+        if artist.artist_spotify_id == nil || artist.artist_spotify_id == ""
           # spotify
-          @spotify_data = event.get_spotify_data(artist.name)
-          if @spotify_data == nil
-            @spotify_artist_id = nil
+          spotify_data = artist.get_spotify_data(artist.name)
+          if spotify_data == nil
+            artist.artist_spotify_id = nil
           else
-            event.spotify_artist_id = @spotify_data.id
+            artist.artist_spotify_id = spotify_data.id
           end
         end
-
-        event.save!
-
-      elsif event.spotify_artist_id == nil || event.spotify_artist_id == ""
-        event.artist_name = artist.name
+        artist.save!
+      elsif artist.artist_spotify_id == nil || artist.artist_spotify_id == ""
         # spotify
-        @spotify_data = event.get_spotify_data(artist.name)
-        if @spotify_data == nil
-          @spotify_artist_id = nil
+        spotify_data = artist.get_spotify_data(artist.name)
+        if spotify_data == nil
+          artist.artist_spotify_id = nil
         else
-          event.spotify_artist_id = @spotify_data.id
+          artist.artist_spotify_id = spotify_data.id
         end
-
-        event.save!
-          
-      else
-        check_event_artist(artist)
+        artist.save!
       end
-      event.save!
-      
     end
+
   end
 
 end

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,0 +1,11 @@
+class ArtistsController < ApplicationController
+
+  before_action :set_artist, only: [:show]
+
+  private
+
+  def set_artist
+    @artist = Artist.find(params[:id])
+  end
+
+end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,23 +22,12 @@ class EventsController < ApplicationController
       current_user.views.create(event_id: params[:id])
     end
 
-    # spotify
-    if @event.artist_name != nil
-      artist_name = @event.artist_name
-      
-      if @event.spotify_artist_id == nil
-        @spotify_data = @event.get_spotify_data(artist_name)
-        if @spotify_data == nil
-          @spotify_artist_id = nil
-        else
-          @spotify_artist_id = @spotify_data.id
-          @event.spotify_artist_id = @spotify_artist_id
-          @event.save
-        end
-      else
-        @spotify_artist_id = @event.spotify_artist_id
-      end
+    if @event.artist
+      @artist = @event.artist
+    else
+      @artist = Artist.new
     end
+
   end
 
   def posts

--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -1,0 +1,2 @@
+module ArtistsHelper
+end

--- a/app/mailers/news_letter_mailer.rb
+++ b/app/mailers/news_letter_mailer.rb
@@ -9,6 +9,6 @@ class NewsLetterMailer < ApplicationMailer
     @events = newly_events
     @user = user
 
-    mail to:  @user.email, subject: "The Wall Weekly Event"
+    mail to:  @user.email, subject: "The Wall Weekly Digest"
   end
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -9,6 +9,6 @@ class NotificationMailer < ApplicationMailer
     @event = interest.event
     @user = interest.user
 
-    mail to: @user.email, subject: "The event(#{@event.title}) will start soon!!"
+    mail to: @user.email, subject: "(#{@event.title}) will start soon!!"
   end
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -7,7 +7,19 @@ class Artist < ApplicationRecord
 
     if artist_name != nil
       require 'rspotify'
-      RSpotify.authenticate("54168cbe8372462f9c62d4e58576f6bc", "c92d63e9f81542c1b65a888cfbb55d70")
+
+      if Rails.env.development?
+        # local用
+        spotify_config = Rails.application.config_for(:spotify)
+        client_id = spotify_config["client_id"]
+        client_secret = spotify_config["client_secret"]
+      elsif Rails.env.production?
+        # heroku用
+        client_id = ENV['SPOTIFY_CLIENT_ID']
+        client_secret = ENV['SPOTIFY_CLIENT__SECRET']
+      end
+
+      RSpotify.authenticate("#{client_id}", "#{client_secret}")
       artist = RSpotify::Artist.search(artist_name)
       artist_data = artist.first
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -65,18 +65,6 @@ class Event < ApplicationRecord
 
   end
 
-  def load_spotify_artist_id(event)
-    if event.spotify_artist_id == nil
-      spotify_data = event.get_spotify_data(event.artist_name)
-      if spotify_data == nil
-        event.spotify_artist_id = nil
-      else
-        event.spotify_artist_id = spotify_data.id
-        event.save
-      end
-    end
-  end
-
   def count_views
     self.views_count += 1
     self.save

--- a/app/views/admin/artists/index.html.erb
+++ b/app/views/admin/artists/index.html.erb
@@ -39,7 +39,7 @@
                 <th scope="row"><%= artist.id %></th>
                 <td><%= artist.created_at.localtime.to_s(:db) %></td>
                 <td><%= artist.updated_at.localtime.to_s(:db) %></td>
-                <td><%= artist.name %></td>
+                <td><%= link_to artist.name, artist_path(artist) %></td>
                 <td><%= link_to '編輯', admin_artists_path(id: artist.id), class: "btn btn-outline-primary" %></td>
                 <td><%= link_to '刪除', admin_artist_path(artist), remote: true, method: :delete, data: {confirm: "ARE YOU SURE?"}, class: "btn btn-outline-danger" %></td>
               </tr>
@@ -61,9 +61,17 @@
         <% end %>
         <%= form_for [:admin, @artist] do |f| %>
           <div class="form-group">
-            <%= f.text_field :name, placeholder: "Artist Name",  class: "form-control" %>
+            <%= f.text_field :name, placeholder: "Artist Name",  class: "form-control" %><br />
+            <% if params[:id] %>
+              <%= f.text_field :artist_video, placeholder: "Artist Youtube Video",  class: "form-control" %><br />
+              <%= f.text_field :artist_spotify_id, placeholder: "Artist Spotify ID",  class: "form-control" %><br />
+            <% end %>
           </div>
-          <%= f.submit class: "btn btn-outline-secondary" %>
+          <%= f.submit class: "btn btn-outline-secondary" %><br />
+          <br />
+          <% if params[:id] %>
+            <%= link_to "重新取得Stream Data", search_admin_artist_path(params[:id]), class: "btn btn-outline-secondary" %><br />
+          <% end %>
         <% end %>
         <br />
 

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -46,7 +46,11 @@
                 <td><%= event.updated_at.localtime.to_s(:db) %></td>
                 <td><%= link_to event.title, event_path(event) %></td>
                 <td><%= event.time.slice(0..4) %></td>
-                <td><%= event.artist_name %></td>
+                <td>
+                  <% if event.artist_name %>
+                    <%= link_to event.artist_name, artist_path(event.artist) %>
+                  <% end %>
+                </td>
                 <td><%= event.city %></td>
                 <td><%= event.stage %></td>
                 <td><%= event.views_count %></td>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,0 +1,91 @@
+<div class="container text-center">
+  <div class="row">
+    <div class="col-12">
+      <h2><%= @artist.name %></h2>
+    </div>
+    
+    <!-- YT&spotify //start -->
+    <% if ( @artist.artist_video != nil && @artist.artist_video != "" ) || ( @artist.artist_spotify_id != nil && @artist.artist_spotify_id != "" ) %>
+      <div class="col-md-12">
+        <div class="subtitle"><strong><i>作品欣賞</i></strong></div>
+        <div class="row">
+
+          <!-- YT //start -->
+          <% if @artist.artist_video != nil && @artist.artist_video != ""  %>
+            <div class="col-md-12 col-sm-12 piece text-center">
+              <div class="piece">【Youtube】</div>
+              <iframe id="existing-iframe-example"
+                      width="600" height="360"
+                      src="<%= @artist.artist_video %>"
+                      frameborder="0"
+                      style="border: none"
+                      allowfullscreen
+              ></iframe>
+            </div><br />
+          <% end %>
+          <!-- YT //end -->
+          
+          <!-- spotify //start -->
+          <% if  @artist.artist_spotify_id != nil && @artist.artist_spotify_id != "" %> <!-- 辨識有無spotify作品 //start-->
+            <div class="col-md-12 col-sm-12 piece text-center">
+              <div class="piece">【Spotify】</div>
+
+                <!-- iframe of spotify follow button -->
+                <iframe src="https://open.spotify.com/follow/1/?uri=spotify:artist:<%= @artist.artist_spotify_id %>&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+                <hr>
+
+                <!-- iframe of spotify playlist -->
+                <iframe src="https://open.spotify.com/embed/artist/<%= @artist.artist_spotify_id %>" width="260" height="350" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+            </div>
+          <% end %><!-- 辨識有無spotify作品 //end-->
+          <!-- spotify //end -->
+        </div>
+      </div>
+    <% end %>
+    <!-- YT&spotify //end -->
+
+    <!-- artist relative events // start -->
+    <div class="col-md-12">
+      <br /><hr>
+      <span class="text-muted"><strong>近期活動</strong></span>  
+    </div><br />
+
+    <% @artist.events.each do |event| %>
+      <div class="col-lg-3 col-md-4 col-sm-12 p-2 d-flex justify-content-center">
+        <%= render partial: "shared/event_list", locals: {object: event, flag: true} %>
+      </div>
+    <% end %>
+    <!-- artist relative events // end -->
+
+    <!-- admin edit YT & Spotify //start -->
+    <% if current_user %>
+      
+      <% if current_user.is_admin %>
+        <div class="col-md-12">
+          <br /><hr>
+          <span class="text-muted"><strong>更新藝人Stream資料</strong></span>  
+        </div><br />
+
+        <div class="col-12">
+          <br /><hr>
+          <%= form_for [:admin, @artist ] do |f| %>
+            <div class="form-group">
+              <%= f.text_field :name, placeholder: "Artist Name",  class: "form-control" %><br />
+              <%= f.text_field :artist_video, placeholder: "Artist Youtube Video",  class: "form-control" %><br />
+              <%= f.text_field :artist_spotify_id, placeholder: "Artist Spotify ID",  class: "form-control" %><br />
+            </div>
+            <div class="text-center">
+              <%= f.submit class: "btn btn-outline-secondary" %><br />
+              <br />
+              <%= f.button "取消變更", type: :reset, class: "btn btn-outline-secondary" %><br /><br />
+              <%= link_to "重新取得Stream Data", search_admin_artist_path(@artist), class: "btn btn-outline-secondary" %><br />
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    <% end%>
+    <!-- admin edit YT & Spotify //end -->
+
+  </div> <!-- .row // end -->
+</div>

--- a/app/views/events/posts.html.erb
+++ b/app/views/events/posts.html.erb
@@ -97,9 +97,6 @@
                       <% i += 1 %>
                     <% end %>
                     <!-- spotify -->
-                    <% if event.spotify_artist_id == nil %>
-                      <% event.load_spotify_artist_id(event) %>
-                    <% end %>
 
                     <% if event.spotify_artist_id != "" && event.spotify_artist_id != nil %>
                       <div class="carousel-item <%= "active" if i == 0 %>">
@@ -147,7 +144,11 @@
               </div>
 
               <div class="col-md-4 post-info">
-                <div class="event-info">演出者 <span><strong><%= event.artist_name %></strong></span></div>
+                <div class="event-info">演出者 
+                  <% if event.artist %>
+                    <span><strong><%= link_to event.artist_name, artist_path(event.artist) %></strong></span>
+                  <% end %>
+                </div>
                 <div class="event-info">城市 <span><%= event.city %></span></div>
                 <div class="event-info">地點 <span><%= event.stage %></span></div>
                 <div class="event-info time">時間 
@@ -164,13 +165,6 @@
                     </span>
                   </span>
                 </div>
-
-                <!-- admin: edit -->
-                <% if current_user %>
-                  <% if current_user.admin? %>
-                    <%= link_to '編輯', edit_admin_event_path(event), class: "btn btn-outline-primary" %>
-                  <% end %>
-                <% end %>
 
               </div>
             </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -20,7 +20,11 @@
         </span>
         
         <h5 class="event-title"><%= @event.title %></h5>
-        <div class="event-info">演出者 <span><%= @event.artist_name %></span></div>
+        <div class="event-info">演出者 
+          <% if @event.artist_name %>
+            <span><%= link_to @event.artist_name, artist_path(@event.artist) %></span>
+          <% end %>
+        </div>
         <!-- <div class="event-info">票價 <span></span></div> -->
         <div class="event-info">城市 <span><%= @event.city %></span></div>
         <div class="event-info">地點 <span><%= @event.stage %></span></div>
@@ -31,6 +35,14 @@
             <span><%= @event.time.slice(0..4) %></span>
           <% end %>
         </div>
+        <!-- admin: edit -->
+        <% if current_user %>
+          <% if current_user.admin? %>
+            <%= link_to '編輯', edit_admin_event_path(@event), class: "btn btn-outline-primary" %>
+            <%= link_to '清除演出者資料', remove_artist_admin_event_path(@event), class: "btn btn-outline-primary" %>
+          <% end %>
+        <% end %>
+
       </div>
 
       <div class="col-md-12"><hr id="event-hr"></div>
@@ -38,7 +50,14 @@
       
       
       <!-- details //start -->
-      <% if @event.video == nil && @spotify_artist_id == nil && @event.video == "" && @spotify_artist_id == "" %>
+      <% if current_user %>
+        <% if current_user.is_admin %>
+          <div class="col-md-7">
+            <div class="subtitle"><i>樂團/表演介紹</i></div>
+            <p class="event-detail" id="detail" ><%= @event.detail %></p>
+          </div>
+        <% end %>
+      <% elsif (@event.video == nil && @event.spotify_artist_id == nil) || (@event.video == "" && @event.spotify_artist_id == "") %>
         <div class="col-md-12">
           <div class="subtitle"><i>樂團/表演介紹</i></div>
           <p class="event-detail" id="detail" ><%= @event.detail %></p>
@@ -52,7 +71,7 @@
       <!-- details //end -->
 
       <!-- YT&spotify //start -->
-      <% if ( @event.video != nil && @event.video != "" ) || ( @spotify_artist_id != nil && @spotify_artist_id != "" ) %>
+      <% if ( @event.video != nil && @event.video != "" ) || ( @event.spotify_artist_id != nil && @event.spotify_artist_id != "" ) %>
         <div class="col-md-5">
           <div class="subtitle"><strong><i>作品欣賞</i></strong></div>
           <div class="row">
@@ -73,24 +92,80 @@
             <!-- YT //end -->
             
             <!-- spotify //start -->
-            <% if  @spotify_artist_id != nil && @spotify_artist_id != "" %> <!-- 辨識有無spotify作品 //start-->
+            <% if  @event.spotify_artist_id != nil && @event.spotify_artist_id != "" %> <!-- 辨識有無spotify作品 //start-->
               <div class="col-md-12 col-sm-12 piece text-center">
                 <div class="piece">【Spotify】</div>
 
                   <!-- iframe of spotify follow button -->
-                  <iframe src="https://open.spotify.com/follow/1/?uri=spotify:artist:<%= @spotify_artist_id %>&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
+                  <iframe src="https://open.spotify.com/follow/1/?uri=spotify:artist:<%= @event.spotify_artist_id %>&size=detail&theme=light" width="300" height="56" scrolling="no" frameborder="0" style="border:none; overflow:hidden;" allowtransparency="true"></iframe>
                   <hr>
 
                   <!-- iframe of spotify playlist -->
-                  <iframe src="https://open.spotify.com/embed/artist/<%= @spotify_artist_id %>" width="260" height="350" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+                  <iframe src="https://open.spotify.com/embed/artist/<%= @event.spotify_artist_id %>" width="260" height="350" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
 
               </div>
             <% end %><!-- 辨識有無spotify作品 //end-->
             <!-- spotify //end -->
           </div>
+            
+          <!-- admin edit YT & Spotify //start -->
+          <% if current_user %>
+            <% if current_user.is_admin && @event.artist %>
+            
+              <div class="col-12 text-center">
+                <br /><hr>
+                <span class="text-muted"><strong>更新演出者Stream資料</strong></span>
+                <br /><br />
+
+                <%= form_for [:admin, @event.artist ] do |f| %>
+                  <div class="form-group">
+                    <%= f.text_field :name, placeholder: "Artist Name",  class: "form-control" %><br />
+                    <%= f.text_field :artist_video, placeholder: "Artist Youtube Video",  class: "form-control" %><br />
+                    <%= f.text_field :artist_spotify_id, placeholder: "Artist Spotify ID",  class: "form-control" %><br />
+                  </div>
+                  <div class="text-center">
+                    <%= f.submit class: "btn btn-outline-secondary" %><br />
+                    <br />
+                    <%= f.button "取消變更", type: :reset, class: "btn btn-outline-secondary" %><br /><br />
+                    <%= link_to "重新取得Stream Data", search_admin_artist_path(@event.artist), class: "btn btn-outline-secondary" %><br />
+                  </div>
+                <% end %>
+              </div>
+            <% end %>
+          <% end%>
+          <br />
+          <!-- admin edit YT & Spotify //end -->
+
         </div>
+        <!-- YT&spotify //end -->
+
+      <% else %>
+        <!-- admin edit YT & Spotify //start -->
+        <% if current_user %>
+          
+          <% if current_user.is_admin %>
+            <div class="col-md-5 col-sm-12 text-center">
+              <br /><hr>
+              <span class="text-muted"><strong>新增藝人</strong></span> 
+              <br /><br />
+
+              <%= form_for [:admin, @artist ] do |f| %>
+                <div class="form-group">
+                  <%= f.text_field :name, placeholder: "Artist Name",  class: "form-control" %><br />
+                </div>
+                <div class="text-center">
+                  <%= f.submit class: "btn btn-outline-secondary" %><br />
+                  <br />
+                  <%= f.button "取消變更", type: :reset, class: "btn btn-outline-secondary" %><br /><br />
+                </div>
+              <% end %>
+            </div>
+          <% end %>
+      
+        <% end%>
+        <!-- admin edit YT & Spotify //end -->
+        <br />
       <% end %>
-      <!-- YT&spotify //end -->
 
     </div> <!-- .row //end -->
   </div>

--- a/app/views/news_letter_mailer/weekly_notification.html.erb
+++ b/app/views/news_letter_mailer/weekly_notification.html.erb
@@ -1,13 +1,18 @@
-<p>
-  <h1>The Wall Weekly Event</h1>
-</p>
-<blockquote>
-  <% @events.each do |event| %>
-    <div class="col-lg-3 col-md-4 col-sm-6">
+<div class="text-center">
+  <p>
+    <h1>The Wall Weekly Events</h1>
+  </p>
+  <blockquote>
+    <div class="container" style="min-width: 100%;" >
+      <div class="row">
+        <% @events.each do |event| %>
+          <div class="col-lg-4 col-md-6 col-sm-10">
 
-      <%= render partial: "shared/mail_events", locals: {object: event, flag: true} %>
+            <%= render partial: "shared/mail_events", locals: {object: event, flag: true} %>
 
+          </div>
+        <% end %> 
+      </div>
     </div>
-  <% end %> 
-</blockquote>
-
+  </blockquote>
+</div>

--- a/app/views/notification_mailer/event_notification.html.erb
+++ b/app/views/notification_mailer/event_notification.html.erb
@@ -2,7 +2,7 @@
   Hi <%= @user.name %>,
 </p>
 <blockquote>
-  The event [<%= @event.title %>] will start at <%= @event.date %>
+  [<%= @event.title %>] will start at <%= @event.date %>
 </blockquote>
 <p>
   Hope you enjoy this event!! 

--- a/app/views/shared/_event_list.html.erb
+++ b/app/views/shared/_event_list.html.erb
@@ -18,7 +18,11 @@
 
   <div class="container-fluid text-center">
     <h6 class="text-center"><%= link_to object.title, event_path(object) %></h6>
-    <div class="artist">演出者 <br /><span><strong><%= object.artist_name %></strong></span></div>
+    <div class="artist">演出者 <br />
+      <% if object.artist %>
+        <span><strong><%= link_to object.artist_name, artist_path(object.artist) %></strong></span>
+      <% end %>
+    </div>
     <% if flag %>
       <div class="place">地點 <br /><span><strong><%= object.stage %></strong></span></div>
      <% end %>

--- a/app/views/shared/_mail_events.html.erb
+++ b/app/views/shared/_mail_events.html.erb
@@ -1,10 +1,10 @@
-<div class="event">
+<div class="event text-center">
 
   <%= link_to event_url(object) do %> 
     <!-- img //start -->
     <div class="img">
-      <%= image_tag object.img, width: "300", height: "300", class: "rounded mx-auto d-block img-fluid" if object.img?%>
-      <%= image_tag "http://via.placeholder.com/300x300", class: "rounded mx-auto d-block img-fluid"  unless object.img?%> 
+      <%= image_tag object.img, width: "600", height: "mx-auto", class: "rounded mx-auto d-block img-fluid" if object.img?%>
+      <%= image_tag "http://via.placeholder.com/600x300", class: "rounded mx-auto d-block img-fluid"  unless object.img?%> 
     </div>
     <!-- img //end -->
   <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,12 +20,24 @@ Rails.application.routes.draw do
   # setup interest
   resources :interests, only: [:create, :destroy] 
 
+  # setup artist
+  resources :artists, only: [:show] 
+
   # setup admin
   namespace :admin do
     root "events#index"
-    resources :events, except: [:show, :new, :create]
+    resources :events, except: [:show, :new, :create] do 
+      member do
+        get :remove_artist
+      end
+    end
+    
     resources :users, only: [:index, :destroy]
-    resources :artists
+    resources :artists do 
+      member do
+        get :search
+      end
+    end
   end
   
 end

--- a/db/migrate/20180407021302_add_column_artist_video_and_spotify_to_artist.rb
+++ b/db/migrate/20180407021302_add_column_artist_video_and_spotify_to_artist.rb
@@ -1,0 +1,6 @@
+class AddColumnArtistVideoAndSpotifyToArtist < ActiveRecord::Migration[5.1]
+  def change
+    add_column :artists, :artist_video, :string
+    add_column :artists, :artist_spotify_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180402015327) do
+ActiveRecord::Schema.define(version: 20180407021302) do
 
   create_table "artists", force: :cascade do |t|
     t.string "name"
@@ -18,6 +18,8 @@ ActiveRecord::Schema.define(version: 20180402015327) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "thewall_artist_id"
+    t.string "artist_video"
+    t.string "artist_spotify_id"
   end
 
   create_table "events", force: :cascade do |t|
@@ -38,6 +40,8 @@ ActiveRecord::Schema.define(version: 20180402015327) do
     t.string "special_id"
     t.string "spotify_artist_id"
     t.string "artist_id"
+    t.string "artist_array", default: "--- []\n"
+    t.string "artists_id_array", default: "--- []\n"
   end
 
   create_table "interests", force: :cascade do |t|

--- a/test/controllers/artists_controller_test.rb
+++ b/test/controllers/artists_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ArtistsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
一. 新增/優化：

- 新增artists#show ,admin/artists#search 和 admin/events#remove_artist routes

- artist model新增 get_spotify_data method

- event model移除 get_spotify_data method

- admin events controller 新增 remove_artist method

- 新增artists controller

- artists table新增artist_video, artist_spotify_id兩欄位

- 自動搜尋藝人Youtube和Spotify的方法，全移至stream.rb並於admin artists controller中使用。

- 後台編輯artist時，顯示欄位artist video 及 artist Spotify ID提供串流內容的更新或移除。

- 後台編輯artist，新增「重新取得Stream Data」的功能，由系統自動重新比對artist name在Youtube和Spotify上的搜尋結果並更新至artist資料中。

- artist資料更新完畢後，所有關聯events中的artist name, Youtube 和 Spotify都會同步更新。

- 新增藝人資訊頁面(artist show)，頁面提供藝人Youtube, Spotify及近期的關聯表演活動(events); 若使用者為管理員，在頁面底部也一併提供「更新藝人Stream資料」區塊讓管理員能即時更新藝人頁面中的藝人名稱及stream data。

- 後台artsits欄位「藝人名稱」中的所有藝人均提供超連結，點擊後即可瀏覽藝人資訊頁面(artist show)。

- 後台events欄位中「演出者」中的所有藝人均提供超連結，點擊後即可瀏覽藝人資訊頁面(artist show)。

- 前台所有event顯示的演出者均提供超連結，點擊後即可瀏覽演出者的藝人資訊頁面(artist show)。

- 表演活動資訊頁面(event show)，新增「編輯」、「清除演出者資料」、有演出者時與後台編輯artist功能相同的「更新演出者Stream資料」及沒有演出者時與後台新增artist功能相同的的「新增藝人」區塊，提供管理員在表演活動資訊頁面(event show)能即時針對該event新增或更新演出者名稱或Stream data。

- get_event:fb_event_new 改寫，原本模式為將event title 或 event detail 與artist比對出「演出者」並依據比對到的演出者名稱做Youtube及Spotify搜尋並將結果存至該event中；現在改寫為將event title 或 event detail 與artist比對出「演出者」並依據比對到的演出者名稱，從artist table中取出Youtube及Spotify stream data存至該event中。


